### PR TITLE
Update pagintor to support newer Django versions

### DIFF
--- a/rawpaginator/paginator.py
+++ b/rawpaginator/paginator.py
@@ -7,7 +7,7 @@ class DatabaseNotSupportedException(Exception):
 
 class RawQuerySetPaginator(DefaultPaginator):
     "An efficient paginator for RawQuerySets."
-
+    _count = None
 
     def __init__(self, object_list, per_page, orphans=0, allow_empty_first_page=True):
         super(RawQuerySetPaginator, self).__init__(object_list, per_page, orphans, allow_empty_first_page)


### PR DESCRIPTION
It appears there is no longer a `_count` in the Pagination class that RawQuerySetPaginator inherits from. This adds a default `_count` to the class.