### PR TITLE
Paginator returns correct class now

### DIFF
--- a/rawpaginator/paginator.py
+++ b/rawpaginator/paginator.py
@@ -70,8 +70,9 @@ class RawQuerySetPaginator(DefaultPaginator):
         data = list(self.raw_query_set.model.objects.raw(query_with_limit, self.raw_query_set.params))
         return Page(data, number, self)
 
-def Paginator(*args, **kwargs):
-    if isinstance(object_list, RawQuerySet):
-        return RawQuerySetPaginator(*args, **kwargs)
-    else:
-        return DefaultPaginator(*args, **kwargs)
+
+class Paginator(object):
+    def __new__(cls, object_list, per_page, *args, **kwargs):
+        cls = (RawQuerySetPaginator if isinstance(object_list, RawQuerySet) else DefaultPaginator)
+        instance = cls(object_list, per_page, *args, **kwargs)
+        return instance


### PR DESCRIPTION
- code previously accessed a not-existing `object_list`
- using a function here instead of a class causes problems if assigned as a class attribute (as it's the case in Django Rest Framework): Python will bind this method, effectively shifting the parameters.